### PR TITLE
Add GitHub Actions deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,23 @@
+name: Deploy Shiny App
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: r-lib/actions/setup-r@v2
+      - name: Install packages
+        run: |
+          Rscript -e 'install.packages(c("shiny","leaflet","leaflet.extras","leaflet.extras2","DT","bslib","shinydashboardPlus","readxl","dplyr","parzer","soilDB","sf","sp","rgdal","raster","leaflet.esri","rmarkdown","rvest","rgeos","rsconnect"), repos="https://cloud.r-project.org")'
+      - name: Deploy app
+        env:
+          SHINY_ACC: ${{ secrets.SHINY_ACC }}
+          SHINY_TOKEN: ${{ secrets.SHINY_TOKEN }}
+          SHINY_SECRET: ${{ secrets.SHINY_SECRET }}
+        run: |
+          Rscript -e 'rsconnect::deployApp(appDir = ".", account = Sys.getenv("SHINY_ACC"), token = Sys.getenv("SHINY_TOKEN"), secret = Sys.getenv("SHINY_SECRET"))'

--- a/README.md
+++ b/README.md
@@ -26,3 +26,13 @@ shiny::runApp("app.R")
 ```
 
 The app loads the precipitation map and the soil organic matter layer and displays them on an interactive Leaflet map.
+
+## Deployment
+A GitHub Actions workflow deploys the app using `rsconnect`. The workflow
+expects the following repository secrets:
+
+- `SHINY_ACC` – your RStudio Connect account name
+- `SHINY_TOKEN` – the deployment token
+- `SHINY_SECRET` – the deployment secret
+
+Set these secrets in your repository settings for automatic deployment.


### PR DESCRIPTION
## Summary
- deploy Shiny app via rsconnect using GitHub Actions
- document required deployment secrets

## Testing
- `Rscript -e "print('R works')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f72ec48d483218f830a3e5bc8e402